### PR TITLE
Fix pkgver causing aur helpers to think theres a new version every time you update packages

### DIFF
--- a/hyprutils-git/.SRCINFO
+++ b/hyprutils-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = hyprutils-git
 	pkgdesc = Hyprland utilities library used across the ecosystem
-	pkgver = 0.7.0.r0.5f51dce
+	pkgver = 0.7.0.r0.g05878d9
 	pkgrel = 1
 	url = https://github.com/hyprwm/hyprutils
 	arch = x86_64

--- a/hyprutils-git/PKGBUILD
+++ b/hyprutils-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgname="hyprutils"
 pkgname="$_pkgname-git"
-pkgver=0.7.0.r0.5f51dce
+pkgver=0.7.0.r0.g05878d9
 pkgrel=1
 pkgdesc="Hyprland utilities library used across the ecosystem"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
Because of the missing `g`, pkgver() always reports a different version than the one installed, which makes my aur helper (paru) think there's an update when there isn't one. Every time I run `paru` it wants to update hyprutils-git.

Fixed by running `makepkg -s` and `makepkg --printsrcinfo > .SRCINFO`.