### PR TITLE
hyprland-git: remove unnecessary source downloads and git config

### DIFF
--- a/hyprland-git/PKGBUILD
+++ b/hyprland-git/PKGBUILD
@@ -5,7 +5,7 @@
 
 _pkgname="hyprland"
 pkgname="$_pkgname-git"
-pkgver=0.54.0.r252.g80763b1
+pkgver=0.55.0.r54.g51d2bb9
 pkgrel=1
 pkgdesc="Hyprland is an independent, highly customizable, dynamic tiling Wayland compositor that doesn't sacrifice on its looks"
 arch=('x86_64' 'aarch64')
@@ -86,12 +86,8 @@ conflicts=("$_pkgname")
 provides=("$_pkgname=${pkgver%%.r*}" "wayland-compositor")
 
 _pkgsrc=$_pkgname
-source=(
-  "$_pkgsrc::git+$url.git"
-)
-sha256sums=(
-  'SKIP'
-)
+source=("$_pkgsrc::git+$url.git")
+sha256sums=('SKIP')
 
 backup=("usr/share/xdg-desktop-portal/hyprland-portals.conf")
 
@@ -99,6 +95,7 @@ prepare() {
   cd "$_pkgsrc"
   git submodule init
   git config submodule.subprojects/tracy.update none
+  git config submodule.subprojects/hyprland-protocols.update none
   git submodule update
 }
 

--- a/hyprland-git/PKGBUILD
+++ b/hyprland-git/PKGBUILD
@@ -88,10 +88,8 @@ provides=("$_pkgname=${pkgver%%.r*}" "wayland-compositor")
 _pkgsrc=$_pkgname
 source=(
   "$_pkgsrc::git+$url.git"
-  "udis86::git+https://github.com/canihavesomecoffee/udis86.git"
 )
 sha256sums=(
-  'SKIP'
   'SKIP'
 )
 
@@ -100,13 +98,8 @@ backup=("usr/share/xdg-desktop-portal/hyprland-portals.conf")
 prepare() {
   cd "$_pkgsrc"
   git submodule init
-  git config submodule.subprojects/udis86.url "$srcdir/udis86"
   git config submodule.subprojects/tracy.update none
-  git -c protocol.file.allow=always submodule update
-
-  if [[ -z "$(git config --get user.name)" ]]; then
-    git config user.name local && git config user.email '<>' && git config commit.gpgsign false
-  fi
+  git submodule update
 }
 
 pkgver() {
@@ -132,5 +125,4 @@ package() {
   cd "$_pkgsrc"
   DESTDIR="$pkgdir" cmake --install build
   install -Dm0644 LICENSE -t "$pkgdir/usr/share/licenses/${pkgname}/"
-  install -Dm0644 subprojects/udis86/LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-udis86"
 }


### PR DESCRIPTION
As part of the cleanup I would suggest getting rid of the udis86 source download as it is automatically fetched by `git submodule update` either way. Also I personally don't like `protocol.file.allow=always` so that's another reason for this refactor. At last, the udis license file is also skipped cause it is not part of the official Hyprland package either and the aim is to get as close to the official package structure as possible.